### PR TITLE
Read zip files into the vector, not an empty slice

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,7 @@ impl Install {
                         let mut contents = Vec::with_capacity(file.size() as usize);
                         use std::io::Read;
                         println!("{:?}", name);
-                        if let Err(e) = file.read(&mut contents) {
+                        if let Err(e) = file.read_to_end(&mut contents) {
                             println!("Could not read file: {:?} {:?}", e, file.compression());
                             continue;
                         }


### PR DESCRIPTION
`read(&[u8])` was reading into the empty slice. We instead want `read_to_end(&mut Vec<u8>)`, which can modify the vector.

There is apparently a bug  (mvdnes/zip-rs#136) in `Crc32Reader` which incorrectly errors when passed a 0 sized buf, it should instead just return Ok(0)